### PR TITLE
Bump jlesage/firefox from v25.07.2 to v25.12.3

### DIFF
--- a/firefox/CHANGELOG.md
+++ b/firefox/CHANGELOG.md
@@ -1,5 +1,13 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 1.8.0
+
+- Base image update: jlesage/docker-firefox to v25.12.3 (Firefox 145.0-r0)
+- Baseimage updated to version 4.10.3:
+  - Fixed desktop notification forwarding service issues related to clients and WebSocket management.
+  - Use Firefox native notification backend when web notification support is disabled.
+- Clipboard synchronization now works with HA Ingress (copy/paste between host and Firefox).
+
 ## 1.7.0
 
 - Base image update: jlesage/docker-firefox to 25.12.1

--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -1,4 +1,4 @@
-FROM jlesage/firefox:v25.07.2
+FROM jlesage/firefox:v25.12.3
 
 COPY rootfs/startapp.sh /startapp.sh
 # Makes sure that the line endings are correct

--- a/firefox/config.yaml
+++ b/firefox/config.yaml
@@ -1,5 +1,5 @@
 name: "Firefox"
-version: "1.7.0"
+version: "1.8.0"
 slug: "firefox"
 panel_icon: "mdi:firefox"
 description: Docker container for Firefox

--- a/firefox_edge/CHANGELOG.md
+++ b/firefox_edge/CHANGELOG.md
@@ -1,5 +1,13 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 1.8.0
+
+- Base image update: jlesage/docker-firefox to v25.12.3 (Firefox 145.0-r0)
+- Baseimage updated to version 4.10.3:
+  - Fixed desktop notification forwarding service issues related to clients and WebSocket management.
+  - Use Firefox native notification backend when web notification support is disabled.
+- Clipboard synchronization now works with HA Ingress (copy/paste between host and Firefox).
+
 ## 1.7.0
 
 - Base image update: jlesage/docker-firefox to 25.12.1

--- a/firefox_edge/Dockerfile
+++ b/firefox_edge/Dockerfile
@@ -1,4 +1,4 @@
-FROM jlesage/firefox:v25.07.2
+FROM jlesage/firefox:v25.12.3
 
 RUN apk del firefox
 RUN sed -r -i -e 's/v[0-9]+\.[0-9]+/edge/g' /etc/apk/repositories

--- a/firefox_edge/config.yaml
+++ b/firefox_edge/config.yaml
@@ -1,5 +1,5 @@
 name: "Firefox (Edge)"
-version: "1.7.0"
+version: "1.8.0"
 slug: "firefox_edge"
 panel_icon: "mdi:firefox"
 description: Docker container for Firefox. Update to the latest Firefox version on container start.


### PR DESCRIPTION
## Summary
- Update base image jlesage/docker-firefox to v25.12.3 (Firefox 145.0-r0)
- Baseimage updated to version 4.10.3 with notification fixes
- Clipboard synchronization now works with HA Ingress

## Changes
- `firefox` and `firefox_edge` addons bumped to version 1.8.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)