### PR TITLE
feat: reintegrate missed v26.02.1 upstream changes and add WEB_TERMINAL

### DIFF
--- a/firefox/CHANGELOG.md
+++ b/firefox/CHANGELOG.md
@@ -1,10 +1,20 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
-## 1.9.2
+## 1.10.0
 
 - Base image update: jlesage/docker-firefox to v26.02.2
-- Updated baseimage to version 4.11.1:
+- Updated baseimage to version 4.11.0 (v26.02.1), then 4.11.1 (v26.02.2):
+  - Added a web terminal providing shell access to the container.
+  - Fixed audio being paused when switching to another browser tab.
+  - Web file manager is now displayed in a modal window.
+  - Fixed file manager failures when uploading zero-byte files.
+  - Fixed upload interruptions from interfering with other uploads.
+  - Enhanced file manager error reporting accuracy.
+  - Improved web services server stability and reliability.
+  - Updated TigerVNC to 1.16.0 and X server to 21.1.21.
   - Fixed issue where taking ownership of directory would fail.
+- Added new environment variable:
+  - WEB_TERMINAL: Enable access to a terminal from the web interface
 
 ## 1.9.1
 

--- a/firefox/config.yaml
+++ b/firefox/config.yaml
@@ -1,5 +1,5 @@
 name: "Firefox"
-version: "1.9.2"
+version: "1.10.0"
 slug: "firefox"
 panel_icon: "mdi:firefox"
 description: Docker container for Firefox
@@ -55,6 +55,7 @@ options:
   WEB_FILE_MANAGER_ALLOWED_PATHS: "AUTO"
   WEB_FILE_MANAGER_DENIED_PATHS: ""
   WEB_NOTIFICATION: "0"
+  WEB_TERMINAL: "0"
   WEB_AUTHENTICATION_TOKEN_VALIDITY_TIME: "24"
 schema:
   VNC_PASSWORD: str
@@ -81,4 +82,5 @@ schema:
   WEB_FILE_MANAGER_ALLOWED_PATHS: str
   WEB_FILE_MANAGER_DENIED_PATHS: str
   WEB_NOTIFICATION: str
+  WEB_TERMINAL: str
   WEB_AUTHENTICATION_TOKEN_VALIDITY_TIME: str

--- a/firefox/translations/en.yaml
+++ b/firefox/translations/en.yaml
@@ -71,6 +71,9 @@ configuration:
   WEB_NOTIFICATION:
     name: Web Notification services
     description: When set to 1, it enables web notification services allowing the browser to display desktop notifications from the application.
+  WEB_TERMINAL:
+    name: Web Terminal
+    description: When set to 1, enables access to a terminal from the web interface, providing shell access to the container.
   WEB_AUTHENTICATION_TOKEN_VALIDITY_TIME:
     name: Web Authentication Token Validity Time
     description: Lifetime of an authentication token, in hours. Default is 24 hours. Only applies when Web Authentication is enabled.

--- a/firefox_edge/CHANGELOG.md
+++ b/firefox_edge/CHANGELOG.md
@@ -1,10 +1,20 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
-## 1.9.2
+## 1.10.0
 
 - Base image update: jlesage/docker-firefox to v26.02.2
-- Updated baseimage to version 4.11.1:
+- Updated baseimage to version 4.11.0 (v26.02.1), then 4.11.1 (v26.02.2):
+  - Added a web terminal providing shell access to the container.
+  - Fixed audio being paused when switching to another browser tab.
+  - Web file manager is now displayed in a modal window.
+  - Fixed file manager failures when uploading zero-byte files.
+  - Fixed upload interruptions from interfering with other uploads.
+  - Enhanced file manager error reporting accuracy.
+  - Improved web services server stability and reliability.
+  - Updated TigerVNC to 1.16.0 and X server to 21.1.21.
   - Fixed issue where taking ownership of directory would fail.
+- Added new environment variable:
+  - WEB_TERMINAL: Enable access to a terminal from the web interface
 
 ## 1.9.1
 

--- a/firefox_edge/config.yaml
+++ b/firefox_edge/config.yaml
@@ -1,5 +1,5 @@
 name: "Firefox (Edge)"
-version: "1.9.2"
+version: "1.10.0"
 slug: "firefox_edge"
 panel_icon: "mdi:firefox"
 description: Docker container for Firefox. Update to the latest Firefox version on container start.
@@ -55,6 +55,7 @@ options:
   WEB_FILE_MANAGER_ALLOWED_PATHS: "AUTO"
   WEB_FILE_MANAGER_DENIED_PATHS: ""
   WEB_NOTIFICATION: "0"
+  WEB_TERMINAL: "0"
   WEB_AUTHENTICATION_TOKEN_VALIDITY_TIME: "24"
 schema:
   VNC_PASSWORD: str
@@ -81,4 +82,5 @@ schema:
   WEB_FILE_MANAGER_ALLOWED_PATHS: str
   WEB_FILE_MANAGER_DENIED_PATHS: str
   WEB_NOTIFICATION: str
+  WEB_TERMINAL: str
   WEB_AUTHENTICATION_TOKEN_VALIDITY_TIME: str

--- a/firefox_edge/translations/en.yaml
+++ b/firefox_edge/translations/en.yaml
@@ -71,6 +71,9 @@ configuration:
   WEB_NOTIFICATION:
     name: Web Notification services
     description: When set to 1, it enables web notification services allowing the browser to display desktop notifications from the application.
+  WEB_TERMINAL:
+    name: Web Terminal
+    description: When set to 1, enables access to a terminal from the web interface, providing shell access to the container.
   WEB_AUTHENTICATION_TOKEN_VALIDITY_TIME:
     name: Web Authentication Token Validity Time
     description: Lifetime of an authentication token, in hours. Default is 24 hours. Only applies when Web Authentication is enabled.    


### PR DESCRIPTION
The v26.02.1 release was missed when the workflow jumped directly from v26.01.1 to v26.02.2. This reintegrates the v26.02.1 changes:
- Web terminal providing shell access to the container
- Audio fix for tab switching
- File manager improvements (modal window, upload fixes, error reporting)
- Web services server stability improvements
- TigerVNC 1.16.0 and X server 21.1.21 updates

Also adds the new WEB_TERMINAL environment variable to both firefox and firefox_edge addon variants.

https://claude.ai/code/session_014cqbnXKcGxho7fwA7So4bX