### PR TITLE
fix(ci): pin home-assistant/builder to 2026.03.2 to fix broken build

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -118,7 +118,7 @@ jobs:
       - name: Pre-pull builder image with retry
         if: steps.check.outputs.build_arch == 'true'
         run: |
-          IMAGE="ghcr.io/home-assistant/amd64-builder:2026.02.1"
+          IMAGE="ghcr.io/home-assistant/amd64-builder:2026.03.2"
           for i in $(seq 1 50); do
             echo "Attempt $i to pull $IMAGE..."
             docker pull "$IMAGE" && break
@@ -129,7 +129,7 @@ jobs:
 
       - name: Build ${{ matrix.addon }} add-on
         if: steps.check.outputs.build_arch == 'true'
-        uses: home-assistant/builder@2026.06.0
+        uses: home-assistant/builder@2026.03.2
         with:
           args: |
             ${{ env.BUILD_ARGS }} \


### PR DESCRIPTION
## Problem

The **Builder** workflow is failing on `main` (since the merge of #106).

The build step fails at:
```
docker pull ghcr.io/home-assistant/amd64-builder:2026.06.0
Error response from daemon: manifest unknown
```

Dependabot (#103) bumped `home-assistant/builder` from `2026.03.2` -> `2026.06.0`. The GitHub **Action** release `2026.06.0` exists, but the matching **builder Docker image** `ghcr.io/home-assistant/amd64-builder:2026.06.0` was never published to ghcr.io. Dependabot only tracks the action tag, so it moved the workflow onto a version with no usable image.

Verified against ghcr.io:

| image tag | ghcr.io |
|---|---|
| `2026.06.0` | 404 (not published) |
| `2026.03.2` | 200 |

## Fix

Pin `home-assistant/builder` back to `2026.03.2` (latest tag with a published image) and align the pre-pull warm-up step to the same tag (it was still `2026.02.1`, warming a different image than the build action used).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
