### PR TITLE
ci: remove max-parallel:1 so add-on builds run concurrently

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -78,7 +78,6 @@ jobs:
     if: needs.init.outputs.changed == 'true'
     name: Build ${{ matrix.arch }} ${{ matrix.addon }} add-on
     strategy:
-      max-parallel: 1
       matrix:
         addon: ${{ fromJson(needs.init.outputs.changed_addons) }}
         arch: ["aarch64", "amd64"]


### PR DESCRIPTION
Removes the `max-parallel: 1` constraint on the Builder build matrix (2 add-ons × 2 arches) so the jobs run concurrently instead of one-at-a-time. This eliminates the sequential per-job runner wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
