### PR TITLE
docs: add Chromium to README, drop unsupported arch badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Add repository on my Home Assistant][repository-badge]][repository-url]
 
-If you want to do add the repository manually, please follow the procedure highlighted in the [Home Assistant website](https://home-assistant.io/hassio/installing_third_party_addons). Use the following URL to add this repository: https://github.com/mincka/ha-addons
+If you want to add the repository manually, please follow the procedure highlighted in the [Home Assistant website](https://home-assistant.io/hassio/installing_third_party_addons). Use the following URL to add this repository: https://github.com/mincka/ha-addons
 
 ## Add-ons provided by this repository
 
@@ -12,8 +12,6 @@ If you want to do add the repository manually, please follow the procedure highl
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports armv7 Architecture][armv7-shield]
-![Supports i386 Architecture][i386-shield]
 
 _Run Firefox as a browser inside Home Assistant to access local or external web sites from your home._
 
@@ -21,8 +19,6 @@ _Run Firefox as a browser inside Home Assistant to access local or external web 
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports armv7 Architecture][armv7-shield]
-![Supports i386 Architecture][i386-shield]
 
 _Run Firefox as a browser inside Home Assistant to access local or external web sites from your home._
 
@@ -33,6 +29,13 @@ The startup speed of the Edge version's add-on tends to become progressively slo
 The Edge version can also be unstable because the compatibility with the VNC add-on is not tested with the latest Firefox version.
 
 If you don’t need the very latest version of Firefox, it’s fine to stay on the standard version.
+
+### [Chromium](./chromium)
+
+![Supports aarch64 Architecture][aarch64-shield]
+![Supports amd64 Architecture][amd64-shield]
+
+_Run Chromium as a browser inside Home Assistant to access local or external web sites from your home._
 
 ## Support
 Got questions?
@@ -47,28 +50,7 @@ If you like this add-on and would like to support my work, you can buy me a coff
 
 Sponsoring available on GitHub (https://github.com/sponsors/Mincka) and Paypal (https://paypal.me/JulienEhrhart).
 
-<!--
-
-Notes to developers after forking or using the github template feature:
-- While developing comment out the 'image' key from 'example/config.yaml' to make the supervisor build the addon
-  - Remember to put this back when pushing up your changes.
-- When you merge to the 'main' branch of your repository a new build will be triggered.
-  - Make sure you adjust the 'version' key in 'example/config.yaml' when you do that.
-  - Make sure you update 'example/CHANGELOG.md' when you do that.
-  - The first time this runs you might need to adjust the image configuration on github container registry to make it public
-  - You may also need to adjust the github Actions configuration (Settings > Actions > General > Workflow > Read & Write)
-- Adjust the 'image' key in 'example/config.yaml' so it points to your username instead of 'home-assistant'.
-  - This is where the build images will be published to.
-- Rename the example directory.
-  - The 'slug' key in 'example/config.yaml' should match the directory name.
-- Adjust all keys/url's that points to 'home-assistant' to now point to your user/fork.
-- Share your repository on the forums https://community.home-assistant.io/c/projects/9
-- Do awesome stuff!
- -->
-
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg
 [repository-badge]: https://img.shields.io/badge/Add%20repository%20to%20my-Home%20Assistant-41BDF5?logo=home-assistant&style=for-the-badge
 [repository-url]: https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fmincka%2Fha-addons

--- a/firefox/README.md
+++ b/firefox/README.md
@@ -4,8 +4,6 @@ _Run Firefox as a browser inside Home Assistant to access local or external web 
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports armv7 Architecture][armv7-shield]
-![Supports i386 Architecture][i386-shield]
 
 ## About
 
@@ -43,5 +41,3 @@ You can import `bookmarks.html` file by dropping them in your `/share/firefox` f
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg

--- a/firefox_edge/README.md
+++ b/firefox_edge/README.md
@@ -4,8 +4,6 @@ _Run Firefox as a browser inside Home Assistant to access local or external web 
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports armv7 Architecture][armv7-shield]
-![Supports i386 Architecture][i386-shield]
 
 ## About
 
@@ -47,5 +45,3 @@ You can import `bookmarks.html` file by dropping them in your `/share/firefox` f
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg


### PR DESCRIPTION
Follow-up to #112 — these README changes were made just after #112 merged, so they didn't ride along.

- List the **Chromium** add-on in the repo README.
- Remove the `armv7`/`i386` architecture badges from the repo README and the Firefox / Firefox (Edge) READMEs (all add-ons declare only `aarch64` + `amd64` in config.yaml).
- Drop the stale developer-notes template block (referenced a non-existent `example/` add-on and the old release flow) and fix a typo.

Docs-only; no add-on `config.yaml`/`Dockerfile`/`rootfs` touched, so no rebuild is triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)