### PR TITLE
docs: fix broken 'Add repository' badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,5 +52,5 @@ Sponsoring available on GitHub (https://github.com/sponsors/Mincka) and Paypal (
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[repository-badge]: https://img.shields.io/badge/Add%20repository%20to%20my-Home%20Assistant-41BDF5?logo=home-assistant&style=for-the-badge
+[repository-badge]: https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg
 [repository-url]: https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fmincka%2Fha-addons


### PR DESCRIPTION
The shields.io badge intermittently times out, so GitHub's camo proxy returned 502 ("Error Fetching Resource") and the image rendered as broken. Replace it with the official my.home-assistant.io badge, which matches the redirect target and renders reliably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)